### PR TITLE
Add headers when passing origin response body

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		w.Header().Set("Content-Type", ct)
 		if cl != "" {
 			w.Header().Set("Content-Length", cl)
 		}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 	defer orgRes.Body.Close()
 
 	ct := orgRes.Header.Get("Content-Type")
+	cl := orgRes.Header.Get("Content-Length")
+
 	if ct != "image/jpeg" {
 		body, err := ioutil.ReadAll(orgRes.Body)
 		if err != nil {
@@ -69,6 +71,11 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 			log.Printf("Read origin body failed. %v\n", err)
 			return
 		}
+
+		if cl != "" {
+			w.Header().Set("Content-Length", cl)
+		}
+
 		w.Write(body)
 		return
 	}


### PR DESCRIPTION
Add `Content-Type` and `Content-Length` headers when passing origin response body.