### PR TITLE
メモリを効率良く使う

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ deps:
 test: deps
 	go test -v
 
+bench: deps
+	go test -bench . -benchmem -benchtime 5s -count 10
+
 build: deps
 	go build
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,12 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, _ := http.NewRequest("GET", orgURL.String(), nil)
+	req, err := http.NewRequest("GET", orgURL.String(), nil)
+	if err != nil {
+		http.Error(w, "Request Failed", http.StatusInternalServerError)
+		log.Printf("Request Failed. %v\n", err)
+		return
+	}
 	req.Header.Set("User-Agent", "oyaki")
 
 	orgRes, err := client.Do(req)


### PR DESCRIPTION
オリジンのレスポンスを読み出してから、プロキシのレスポンスとして返却する際に、 `io.ReadAll` で全部読み出してしまうと、メモリをその分確保してしまうので、 `io.Copy` でそのまま書くようにしました。パフォーマンス差異は下記のとおりです。

### before
```
goos: darwin
goarch: amd64
pkg: github.com/yano3/oyaki
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkProxyJpeg-16                120          49988743 ns/op         2694188 B/op        256 allocs/op
BenchmarkProxyJpeg-16                100          50009041 ns/op         2698791 B/op        258 allocs/op
BenchmarkProxyJpeg-16                120          49992764 ns/op         2697882 B/op        257 allocs/op
BenchmarkProxyJpeg-16                120          49991719 ns/op         2698167 B/op        256 allocs/op
BenchmarkProxyJpeg-16                100          50000306 ns/op         2694079 B/op        255 allocs/op
BenchmarkProxyJpeg-16                120          50005491 ns/op         2691790 B/op        253 allocs/op
BenchmarkProxyJpeg-16                120          50004532 ns/op         2690716 B/op        253 allocs/op
BenchmarkProxyJpeg-16                120          49963438 ns/op         2693607 B/op        253 allocs/op
BenchmarkProxyJpeg-16                100          50003846 ns/op         2692012 B/op        253 allocs/op
BenchmarkProxyJpeg-16                100          50092903 ns/op         2692335 B/op        253 allocs/op
BenchmarkProxyPNG-16                1633           4035713 ns/op        11811499 B/op        239 allocs/op
BenchmarkProxyPNG-16                1546           3950912 ns/op        11810461 B/op        240 allocs/op
BenchmarkProxyPNG-16                1572           3906291 ns/op        11811901 B/op        241 allocs/op
BenchmarkProxyPNG-16                1354           4106451 ns/op        11811504 B/op        240 allocs/op
BenchmarkProxyPNG-16                1496           3937820 ns/op        11811191 B/op        241 allocs/op
BenchmarkProxyPNG-16                1540           3996129 ns/op        11811766 B/op        240 allocs/op
BenchmarkProxyPNG-16                1416           4145011 ns/op        11811180 B/op        240 allocs/op
BenchmarkProxyPNG-16                1524           4032658 ns/op        11811412 B/op        240 allocs/op
BenchmarkProxyPNG-16                1482           3866915 ns/op        11811570 B/op        241 allocs/op
BenchmarkProxyPNG-16                1371           3872179 ns/op        11811116 B/op        241 allocs/op
PASS
ok      github.com/yano3/oyaki  150.750s
```

### after
```
goos: darwin
goarch: amd64
pkg: github.com/yano3/oyaki
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkProxyJpeg-16                120          49978492 ns/op         2711704 B/op        269 allocs/op
BenchmarkProxyJpeg-16                120          50414767 ns/op         2712359 B/op        269 allocs/op
BenchmarkProxyJpeg-16                120          50855087 ns/op         2706675 B/op        264 allocs/op
BenchmarkProxyJpeg-16                100          50393175 ns/op         2701453 B/op        262 allocs/op
BenchmarkProxyJpeg-16                100          50221439 ns/op         2706123 B/op        263 allocs/op
BenchmarkProxyJpeg-16                100          50318901 ns/op         2705379 B/op        261 allocs/op
BenchmarkProxyJpeg-16                100          50495051 ns/op         2702505 B/op        260 allocs/op
BenchmarkProxyJpeg-16                100          50347247 ns/op         2700782 B/op        261 allocs/op
BenchmarkProxyJpeg-16                100          50260454 ns/op         2699452 B/op        261 allocs/op
BenchmarkProxyJpeg-16                100          50260666 ns/op         2703747 B/op        261 allocs/op
BenchmarkProxyPNG-16                2013           2989629 ns/op         6004774 B/op        216 allocs/op
BenchmarkProxyPNG-16                2041           3034201 ns/op         6004761 B/op        216 allocs/op
BenchmarkProxyPNG-16                1792           3022694 ns/op         6003230 B/op        215 allocs/op
BenchmarkProxyPNG-16                2154           3104556 ns/op         6003272 B/op        215 allocs/op
BenchmarkProxyPNG-16                1837           3085853 ns/op         6003884 B/op        215 allocs/op
BenchmarkProxyPNG-16                1820           3080824 ns/op         6003541 B/op        215 allocs/op
BenchmarkProxyPNG-16                1820           3077971 ns/op         6002960 B/op        215 allocs/op
BenchmarkProxyPNG-16                1972           3139781 ns/op         6003321 B/op        214 allocs/op
BenchmarkProxyPNG-16                1959           3132350 ns/op         6002362 B/op        214 allocs/op
BenchmarkProxyPNG-16                2018           3049747 ns/op         6002913 B/op        214 allocs/op
PASS
ok      github.com/yano3/oyaki  132.505s
```
項目は左から順に、下記のとおりです。
```
実行した回数
１回あたりの実行に掛かった時間(ns/op)
１回あたりのアロケーションで確保した容量(B/op)
1回あたりのアロケーション回数(allocs/op) 
```

Jpegは画像変換が支配的なのであまり差分はありませんが、Jpeg以外の画像の場合にかなり改善が見込めます。