### PR TITLE
Refactor print version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          build-args: OYAKI_VERSION=${{ steps.meta.outputs.version }}
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bin/
+/oyaki

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1.16-buster AS build
 
+ARG OYAKI_VERSION
+
 WORKDIR /go/src/oyaki
 COPY . /go/src/oyaki
 
-RUN make build
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${OYAKI_VERSION}" -o /go/bin/oyaki
 
 FROM gcr.io/distroless/static-debian10
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-VERSION := $(shell git tag | grep ^v | sort -V | tail -n 1)
 deps:
 	go get -d -t ./...
 
@@ -9,7 +8,7 @@ bench: deps
 	go test -bench . -benchmem -benchtime 5s -count 10
 
 build: deps
-	CGO_ENABLED=0 go build -o ./bin/oyaki -ldflags "-X main.version=$(VERSION)"
+	CGO_ENABLED=0 go build
 
 lint:
 	go vet

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bench: deps
 	go test -bench . -benchmem -benchtime 5s -count 10
 
 build: deps
-	CGO_ENABLED=0 go build -o ./bin/oyaki  -ldflags "-X main.version=$(VERSION)"
+	CGO_ENABLED=0 go build -o ./bin/oyaki -ldflags "-X main.version=$(VERSION)"
 
 lint:
 	go vet

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"syscall"
 	"time"
@@ -26,7 +27,7 @@ func main() {
 	flag.Parse()
 
 	if ver {
-		fmt.Printf("oyaki %s\n", version)
+		fmt.Printf("oyaki %s\n", getVersion())
 		return
 	}
 
@@ -127,4 +128,16 @@ func proxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	return
+}
+
+func getVersion() string {
+	if version != "" {
+		return version
+	}
+
+	i, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	return i.Main.Version
 }

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func getVersion() string {
 
 	i, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "dev"
+		return "(unknown)"
 	}
 	return i.Main.Version
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	flag.Parse()
 
 	if ver {
-		fmt.Println("oyaki version", version)
+		fmt.Printf("oyaki %s\n", version)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,13 +20,12 @@ var quality = 90
 var version = ""
 
 func main() {
-	var withVersion bool
+	var ver bool
 
-	flag.BoolVar(&withVersion, "version", false, "show version")
-
+	flag.BoolVar(&ver, "version", false, "show version")
 	flag.Parse()
 
-	if withVersion {
+	if ver {
 		fmt.Println("oyaki version", version)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ var version = ""
 
 func main() {
 	var withVersion bool
-	flag.BoolVar(&withVersion, "v", false, "show version")
 
 	flag.BoolVar(&withVersion, "version", false, "show version")
 


### PR DESCRIPTION
Refactor print version.

- Embed version from git tag when release.
- Use build information when installed by `go get`.
- Remove `-v` option.